### PR TITLE
Fix normalized not returning a Quaternion if unit

### DIFF
--- a/tinyquaternion/tinyQuaternion.py
+++ b/tinyquaternion/tinyQuaternion.py
@@ -88,7 +88,7 @@ class Quaternion:
                 # self.q /= n # this will change the main object
                 return self.__class__(q= self.q / n)
 
-        return self.q
+        return self.__class__(q=self.q)
          
 
     @property


### PR DESCRIPTION
Fixes:
- If the vector being normalized is unit vector the normalized method will return a numpy array
